### PR TITLE
Fix CommentToken for parsing comment when multi-line comments appear in the single-line comment

### DIFF
--- a/test/common/ParsingCommentTest.green
+++ b/test/common/ParsingCommentTest.green
@@ -33,6 +33,18 @@ void TestFunc7(int n) {
     assert(n == 0);
 }
 
+void TestFunc8(int n) {
+    /*
+       // assert(n == 1)
+     */
+    assert(n == 0);
+}
+
+void TestFunc9(int n) {
+    // /*assert(n == 1)*/
+    assert(n == 0);
+}
+
 @Export
 int main() {
     TestFunc(0);
@@ -42,6 +54,8 @@ int main() {
     TestFunc5(0);
     TestFunc6(0);
     TestFunc7(0);
+    TestFunc8(0);
+    TestFunc9(0);
     return 0;
 }
 


### PR DESCRIPTION
In current version, we cannot parse following code.
This pull request support parsing comment when multi-line comments appear in the single-line comment.

```
$ cat hoge.green
int f() {
    // assert(n == 1)// */
}
```

```
$ java -jar GreenTeaScript.jar hoge.green
(error) (hoge.green:1) expected name; given = {
(info) (hoge.green:2) skipping:
(info) (hoge.green:2) skipping: /
(info) (hoge.green:2) skipping: /
(info) (hoge.green:2) skipping: assert
(info) (hoge.green:2) skipping: (
(info) (hoge.green:2) skipping: n
(info) (hoge.green:2) skipping: ==
(info) (hoge.green:2) skipping: 1
(info) (hoge.green:2) skipping: )
(info) (hoge.green:2) skipping: /
(info) (hoge.green:2) skipping: /
(info) (hoge.green:2) skipping: *
(info) (hoge.green:2) skipping: /
(info) (hoge.green:3) skipping:
(info) (hoge.green:3) stopping script eval at }
abort loading: hoge.green
```
