### PR TITLE
bug fixed : If the script has more than one new line, TokenContext produce wrong line numbers.

### DIFF
--- a/src/org/GreenTeaScript/KonohaGrammar.java
+++ b/src/org/GreenTeaScript/KonohaGrammar.java
@@ -136,6 +136,9 @@ public class KonohaGrammar extends GtGrammar {
 			if(!LibGreenTea.IsWhitespace(SourceText, pos)) {
 				break;
 			}
+			if(LibGreenTea.CharAt(SourceText, pos) == '\n') {
+				TokenContext.FoundLineFeed(1);
+			}
 			pos += 1;
 		}
 		/*local*/String Text = "";

--- a/test/codegen/0045-LineNumber.green
+++ b/test/codegen/0045-LineNumber.green
@@ -1,0 +1,9 @@
+// written by imasahiro
+@Export int main() {
+
+
+
+
+    assert(__line__ == 7);
+    return 0;
+}


### PR DESCRIPTION
Parser generates wrong line number when scripts has more than one new lines.

```
 cat -n test/codegen/0045-LineNumber.green
     1  //
     2  @Export int main() {
     3
     4
     5
     6
     7      println(__line__);
     8      return 0;
     9  }
```

```
$ java -jar GreenTeaScript.jar test/codegen/0045-LineNumber.green
(test/codegen/0045-LineNumber.green:3) <---- this must be 7
```
